### PR TITLE
No longer update the stock on the spreadsheet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## On the market sheet you need to set some named ranges. This is so that added/removed rows will not affect functionality of the website.:
 
-- "ItemNames": This should be the entire list of item names on the google sheet, EXCLUDING the header row. As of the time of writing this, it is "PurchasePrices!D2:D1000"
+- ~"ItemNames": This should be the entire list of item names on the google sheet, EXCLUDING the header row. As of the time of writing this, it is "PurchasePrices!D2:D1000"~ (no longer necessary as the app no longer tries to push updates to the non-public `PurchasePrices` sheet).
 - "ItemNamesPublic": This is the list of item names on the _public_ prices sheet, which is a filtered version of the other list. Do not include header row.
-- "ItemStock": This is the current stock value from the non-public sheet. This is the range that the website will UPDATE when orders are completed. Do not include header row.
+- ~"ItemStock": This is the current stock value from the non-public sheet. This is the range that the website will UPDATE when orders are completed. Do not include header row.~ No longer necessary, app no longer pushes updates to this sheet.
 - "PurchaseWebsiteData": This is basically the entire PurchasePricesPublic table, including the header rows ("PurchasePricesPublic!A1:I945")

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -24,12 +24,12 @@ class OrdersController < ApplicationController
   def index
     # Yes this query stuff should be in the model,
     # sue me.
-    @orders = Order.preload(:line_items).left_outer_joins(:stock_modifier_queue).order(id: :asc)
+    @orders = Order.preload(:line_items).order(id: :asc)
 
     if params[:completed]
-      @orders = @orders.where("stock_modifier_queues.executed_at IS NOT NULL")
+      @orders = @orders.where(status: "complete")
     else
-      @orders = @orders.where("stock_modifier_queues.executed_at IS NULL")
+      @orders = @orders.where.not(status: "complete")
     end
   end
 

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -6,10 +6,10 @@ module OrdersHelper
   def order_status_badge_class(order)
     if order.pending?
       "badge-secondary"
-    elsif order.pending_stock_update?
-      "badge-info"
     elsif order.complete?
       "badge-success"
+    elsif order.cancelled?
+      "badge-danger"
     end
   end
 end

--- a/app/models/purchase_price_sheet.rb
+++ b/app/models/purchase_price_sheet.rb
@@ -34,6 +34,7 @@ class PurchasePriceSheet < GoogleSheet
   end
 
   def update_current_stock(update_list)
+    raise "Deprecated update_current_stock: This app no longer pushes updates to the stock spreadsheet"
     # This is done in the scheduler task that also collects the data
     # initially... It would be a little more efficient to do this at the same
     # time you're initially looping through the rows, but also more complex to

--- a/app/models/stock_modifier_queue.rb
+++ b/app/models/stock_modifier_queue.rb
@@ -1,3 +1,5 @@
+# DEPRECATED: This app no longer pushes any data to
+# the stock spreadsheet.
 class StockModifierQueue < ApplicationRecord
   belongs_to :order
 

--- a/app/views/line_items/_line_item.html.haml
+++ b/app/views/line_items/_line_item.html.haml
@@ -8,7 +8,7 @@
   %td
     = isk_currency line_item.total
   %td
-    - if !line_item.order.complete? && line_item.pending_stock?
+    - if line_item.order.pending? && line_item.pending_stock?
       .badge.badge-danger{data: {toggle: "tooltip"}, title: "Corp will need to manufacture or source some or all of this item"}
         No
     - else

--- a/app/views/orders/show.html.haml
+++ b/app/views/orders/show.html.haml
@@ -26,12 +26,6 @@
     For:
     = @order.player_name
 
-  - if @order.stock_modifier_queue&.complete?
-    %p
-      Stock Updated:
-      = time_ago_in_words(@order.stock_modifier_queue.executed_at)
-      ago
-
   .table-responsive
     %table.table.table-striped.table-dark.table-hover
       %thead

--- a/lib/tasks/update_prices.rake
+++ b/lib/tasks/update_prices.rake
@@ -2,7 +2,7 @@ namespace :update_prices do
   desc "Update stock & prices in the DB based on the ALI Market spreadsheet"
   task go: :environment do
     CorpStock.update_from_spreadsheet!
-    StockModifierQueue.run!
+    # StockModifierQueue.run!
   end
 
 end


### PR DESCRIPTION
Instead of pushing stock updates to the stock spreadsheet, the app will
keep stock values cached for 1 day, and refresh stock/prices on a daily
basis. Orders that get completed will update the cache.

Fixes #1